### PR TITLE
Fix URL is not defined error

### DIFF
--- a/lib/Request.js
+++ b/lib/Request.js
@@ -1,4 +1,5 @@
 const fetch = require('node-fetch')
+const URL = require('url').URL
 
 module.exports = class Request {
     constructor(){


### PR DESCRIPTION
Hi there. I just installed this library and was testing it out because I wanted to use the Jikan API. But, I had a problem when trying to use it. Basically when I tried to use the example given in the README, I got an error that looked like this:

```
ReferenceError: URL is not defined
    at Request.createUrl (C:\tests\node-jikan\node_modules\jikan-node\lib\Request.js:16:21)
    at Request.send (C:\tests\node-jikan\node_modules\jikan-node\lib\Request.js:9:36)
    at JikanNode.findAnime (C:\tests\node-jikan\node_modules\jikan-node\jikan-node.js:16:35)
    at Object.<anonymous> (C:\tests\node-jikan\test.js:4:5)
    at Module._compile (module.js:652:30)
    at Object.Module._extensions..js (module.js:663:10)
    at Module.load (module.js:565:32)
    at tryModuleLoad (module.js:505:12)
    at Function.Module._load (module.js:497:3)
    at Function.Module.runMain (module.js:693:10)
```

I found out pretty quick that I just needed to add something like this to my file and it would work.

```javascript
const URL = require('url').URL
```

Now of course its entirely possible that I was just doing something wrong (I haven't really been using this for too long), but changing the Request.js to add that line seems to have fixed the library completely for me. So this pull request just adds that line to Request.js to fix this problem. If there's any questions you can let me know, and thank you for making this library!!