### PR TITLE
Fix genre_exclude = 0 not working

### DIFF
--- a/lib/Request.js
+++ b/lib/Request.js
@@ -17,10 +17,8 @@ module.exports = class Request {
         const url = new URL(this.baseURL)
         url.pathname += `/${args.filter(a => a).join("/")}`
             for (let p in params) {
-                if (params[p]) {
-                    url.searchParams.set(p, params[p])
+                url.searchParams.set(p, params[p])
             }
-        }
         return url.href
     }
 }


### PR DESCRIPTION
Hey there. I stumbled upon this Jikan wrapper when I was looking to use Jikan for my Discord bot.
I found a bug when I was trying to use the `genre_exclude` advanced search option.
```javascript
const Jikan = require('jikan-node');
const mal = new Jikan();

let searchOptions = {
  limit: 100,
  genre_exclude: 0,
  genre: 12
};
let searchResults = mal.search('anime', 'test', searchOptions);
```
The documentation has that value as a [boolean 0/1](https://jikan.docs.apiary.io/#reference/0/search), but when I set that parameter to `0` it does not exclude those genre IDs.
Rather, it functions as if the `genre_exclude` parameter was never set since `params[p]` would evaluate as `false`.
This PR just removes that if-statement. Thanks for writing this wrapper!
